### PR TITLE
fix: code examples blocks

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,9 +1,8 @@
 {
   "extends": "stylelint-config-standard",
-  "plugins": [
-    "stylelint-order"
-  ],
+  "plugins": ["stylelint-order"],
   "rules": {
-    "order/properties-alphabetical-order": true
+    "order/properties-alphabetical-order": true,
+    "custom-property-empty-line-before": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-minimalist",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A minimal pure CSS starter library for most web projects.",
   "type": "module",
   "exports": "./src/index.js",

--- a/src/minimalist/atoms/forms.css
+++ b/src/minimalist/atoms/forms.css
@@ -16,15 +16,6 @@ textarea {
 }
 
 input:user-valid,
-input:user-invalid,
-input:focus:invalid:not(:user-invalid),
-textarea:user-valid,
-textarea:user-invalid,
-textarea:focus:invalid:not(:user-invalid) {
-  outline-offset: var(--size-2);
-}
-
-input:user-valid,
 textarea:user-valid {
   border-color: var(--color-valid-border);
   outline-color: var(--color-valid-outline);
@@ -34,6 +25,15 @@ input:user-invalid,
 textarea:user-invalid {
   border-color: var(--color-error-border);
   outline-color: var(--color-error-outline);
+}
+
+input:user-valid,
+input:user-invalid,
+input:focus:invalid:not(:user-invalid),
+textarea:user-valid,
+textarea:user-invalid,
+textarea:focus:invalid:not(:user-invalid) {
+  outline-offset: var(--size-2);
 }
 
 input:focus:invalid:not(:user-invalid),

--- a/src/minimalist/atoms/table.css
+++ b/src/minimalist/atoms/table.css
@@ -42,6 +42,7 @@ tfoot {
   background-color: var(--table-tfoot-background);
   color: var(--table-tfoot-foreground);
 
+  /* stylelint-disable-next-line no-descending-specificity */
   td {
     padding: var(--table-tfoot-spacing);
   }

--- a/src/minimalist/atoms/text.css
+++ b/src/minimalist/atoms/text.css
@@ -12,11 +12,8 @@ blockquote p:not(:last-child) {
   margin-block-end: var(--size-8);
 }
 
-code {
-  -webkit-box-decoration-break: clone;
-  box-decoration-break: clone;
-  white-space: nowrap;
-  word-wrap: break-word;
+pre {
+  padding: var(--minimalist-pre-padding, var(--size-16));
 }
 
 :is(h1, h2, h3, h4, h5, h6) code {

--- a/src/minimalist/minimalist.css
+++ b/src/minimalist/minimalist.css
@@ -1,18 +1,17 @@
-@layer reset, utils, core, components;
+@layer minimalist-reset, minimalist-utils, minimalist-core;
 
-@import "./utils/reset.css" layer(reset);
-
-@import "./utils/utils.css" layer(utils);
-
-@import "./tokens/custom-properties.css" layer(core);
-@import "./atoms/button.css" layer(core);
-@import "./atoms/typography.css" layer(core);
-@import "./atoms/text.css" layer(core);
-@import "./atoms/forms.css" layer(core);
-@import "./atoms/table.css" layer(core);
-@import "./atoms/media.css" layer(core);
+@import url("./utils/reset.css") layer(minimalist-reset);
+@import url("./utils/utils.css") layer(minimalist-utils);
+@import url("./tokens/custom-properties.css") layer(minimalist-core);
+@import url("./atoms/button.css") layer(minimalist-core);
+@import url("./atoms/typography.css") layer(minimalist-core);
+@import url("./atoms/text.css") layer(minimalist-core);
+@import url("./atoms/forms.css") layer(minimalist-core);
+@import url("./atoms/table.css") layer(minimalist-core);
+@import url("./atoms/media.css") layer(minimalist-core);
 
 :root {
+  /* Custom properties */
   --link-color: var(--color-link-color, mediumblue);
   --link-color-visited: var(--color-link-visited-color, darkmagenta);
   --link-focus-visible-box-shadow: 0 0 0 var(--size-2)

--- a/src/minimalist/tokens/custom-properties.css
+++ b/src/minimalist/tokens/custom-properties.css
@@ -11,7 +11,7 @@
   --color-link-color: #0342a4;
   --color-link-visited-color: #561c4a;
 
-  --color-neutral-inverted-transparent-70: rgba(255, 255, 255, 0.7);
+  --color-neutral-inverted-transparent-70: rgba(255 255 255 0.7);
   --color-neutral-inverted: #fff;
 
   --color-neutral-10: #f4f4f4;
@@ -75,7 +75,7 @@
     var(--color-neutral-20)
   );
 
-  --overlay-background-color: rgba(0, 0, 0, 0.5);
+  --overlay-background-color: rgba(0 0 0 0.5);
 
   /* shadows */
   --shadow-button-active-state: 1px 1px 0 3px var(--color-neutral-30),
@@ -101,14 +101,14 @@
   --section-top-margin: var(--spacing-wide);
 
   /* typography - https://systemfontstack.com */
-  --typography-heading-family: Iowan Old Style, Apple Garamond, Baskerville,
-    Times New Roman, Droid Serif, Times, Source Serif Pro, serif,
-    Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-  --typography-body-family: -apple-system, BlinkMacSystemFont, avenir next,
-    avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto,
-    arial, sans-serif;
-  --typography-code-family: Menlo, Consolas, Monaco, Liberation Mono,
-    Lucida Console, monospace;
+  --typography-heading-family: iowan old style, apple garamond, baskerville,
+    times new roman, droid serif, times, source serif pro, serif,
+    apple color emoji, segoe ui emoji, segoe ui symbol;
+  --typography-body-family: -apple-system, blinkmacsystemfont, avenir next,
+    avenir, segoe ui, helvetica neue, helvetica, cantarell, ubuntu, roboto,
+    noto, arial, sans-serif;
+  --typography-code-family: menlo, consolas, monaco, liberation mono,
+    lucida console, monospace;
 
   --typography-size-display: 3.815rem; /* 61px */
   --typography-size-xxl: 3.052rem; /* 49px */
@@ -123,6 +123,7 @@
   --typography-document-line-height: 1.75;
   --typography-code-example-line-height: 1.4;
   --typography-heading-line-height: 1.2;
+
   /* reduced line height for interactive elements */
   --typography-iactive-line-height: 1.1;
 
@@ -134,7 +135,7 @@
   --top-layer: 300;
 }
 
-@media only screen and (min-width: 63.9375rem) {
+@media only screen and (width >= 63.9375rem) {
   :root {
     --typography-size-display: 5.61rem; /* 90px */
     --typography-size-xxl: 4.209rem; /* 67px */

--- a/src/minimalist/utils/reset.css
+++ b/src/minimalist/utils/reset.css
@@ -12,10 +12,14 @@
 }
 
 /* Prevent font size inflation */
+
 /* https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/ */
+
 /* https://caniuse.com/text-size-adjust */
 html {
+  /* stylelint-disable-next-line property-no-vendor-prefix */
   -moz-text-size-adjust: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-text-size-adjust: none;
   text-size-adjust: none;
 }
@@ -35,16 +39,16 @@ dd {
 
 /* Set core body defaults */
 body {
+  /* If supported, inherits the iOS font settings
+     More at https://frontendmasters.com/blog/letting-ios-text-size-setting-affect-font-size-on-the-web/ */
+  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+  font: -apple-system-body;
+  font-size: 100%; /* Respect user choice */
   line-height: var(--typography-document-line-height);
   min-block-size: 100vh;
-  font-size: 100%; /* Respect user choice */
-
-  /* If supported, inherits the iOS font settings 
-     More at https://frontendmasters.com/blog/letting-ios-text-size-setting-affect-font-size-on-the-web/ */
-  font: -apple-system-body;
 
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#browser_compatibility */
-  text-rendering: optimizeLegibility;
+  text-rendering: optimizelegibility;
 }
 
 summary {
@@ -72,6 +76,7 @@ textarea:not([rows]) {
 }
 
 /* Balance text wrapping on headings */
+
 /* https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#balance */
 h1,
 h2,


### PR DESCRIPTION
- This fixes the display of code block and adds default padding to the `pre` element. 
- Adds `--minimalist-pre-padding` which a user can override if they prefer different padding. 
- Several Stylelint reported errors.
- Disables `custom-property-empty-line-before` Stylelint rule.

fix #76