### PR TITLE
Update font family custom property names to be namespaced

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-minimalist",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A minimal pure CSS starter library for most web projects.",
   "type": "module",
   "exports": "./src/index.js",

--- a/src/minimalist/atoms/typography.css
+++ b/src/minimalist/atoms/typography.css
@@ -11,15 +11,15 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--typography-heading-family);
-  line-height: var(--typography-heading-line-height);
+  font-family: var(--minimalist-typography-heading-family);
+  line-height: var(--minimalist-typography-heading-line-height);
 }
 
 .text-medium,
 .text-small-medium,
 body {
-  font-family: var(--typography-body-family);
-  line-height: var(--typography-document-line-height);
+  font-family: var(--minimalist-typography-body-family);
+  line-height: var(--minimalist-typography-document-line-height);
 }
 
 .heading-display {
@@ -76,7 +76,7 @@ body {
 }
 
 code {
-  font-family: var(--typography-code-family);
+  font-family: var(--minimalist-typography-code-family);
   font-size: var(--typography-size-default);
-  line-height: var(--typography-code-example-line-height);
+  line-height: var(--minimalist-typography-code-example-line-height);
 }

--- a/src/minimalist/tokens/custom-properties.css
+++ b/src/minimalist/tokens/custom-properties.css
@@ -144,13 +144,13 @@
   --table-tfoot-padding-inline: var(--size-8);
 
   /* typography - https://systemfontstack.com */
-  --typography-heading-family: iowan old style, apple garamond, baskerville,
-    times new roman, droid serif, times, source serif pro, serif,
+  --minimalist-typography-heading-family: iowan old style, apple garamond,
+    baskerville, times new roman, droid serif, times, source serif pro, serif,
     apple color emoji, segoe ui emoji, segoe ui symbol;
-  --typography-body-family: -apple-system, blinkmacsystemfont, avenir next,
-    avenir, segoe ui, helvetica neue, helvetica, cantarell, ubuntu, roboto,
-    noto, arial, sans-serif;
-  --typography-code-family: menlo, consolas, monaco, liberation mono,
+  --minimalist-typography-body-family: -apple-system, blinkmacsystemfont,
+    avenir next, avenir, segoe ui, helvetica neue, helvetica, cantarell, ubuntu,
+    roboto, noto, arial, sans-serif;
+  --minimalist-typography-code-family: menlo, consolas, monaco, liberation mono,
     lucida console, monospace;
 
   --minimalist-typography-scale-mobile: 1.25;
@@ -183,12 +183,12 @@
     var(--typography-size-small) / var(--minimalist-typography-scale-mobile)
   ); /* 9px */
 
-  --typography-document-line-height: 1.75;
-  --typography-code-example-line-height: 1.4;
-  --typography-heading-line-height: 1.2;
+  --minimalist-typography-document-line-height: 1.75;
+  --minimalist-typography-code-example-line-height: 1.4;
+  --minimalist-typography-heading-line-height: 1.2;
 
   /* reduced line height for interactive elements */
-  --typography-interactive-line-height: 1.1;
+  --minimalist-typography-interactive-line-height: 1.1;
 
   /* z-index scale */
   --send-to-back: -1;

--- a/src/minimalist/utils/reset.css
+++ b/src/minimalist/utils/reset.css
@@ -44,7 +44,7 @@ body {
   /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
   font: -apple-system-body;
   font-size: 100%; /* Respect user choice */
-  line-height: var(--typography-document-line-height);
+  line-height: var(--minimalist-typography-document-line-height);
   min-block-size: 100vh;
 
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#browser_compatibility */
@@ -59,7 +59,7 @@ summary {
 button,
 input,
 label {
-  line-height: var(--typography-interactive-line-height);
+  line-height: var(--minimalist-typography-interactive-line-height);
 }
 
 /* Remove built-in form typography styles */


### PR DESCRIPTION
A user can now easily override the entire font scale on both mobile and larger viewports using the following custom properties:

```css
--minimalist-typography-scale-mobile
--minimalist-typography-scale-desktop
```

The breaking change relates to changes to some of the typography-related custom properties in the `tokens/typography.css` file. These now start with `--minimalist-` to follow the namespaced convention.