### PR TITLE
bug: fix typo in typography class names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-minimalist",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "A minimal pure CSS starter library for most web projects.",
   "type": "module",
   "exports": "./src/index.js",

--- a/src/minimalist/atoms/typography.css
+++ b/src/minimalist/atoms/typography.css
@@ -3,7 +3,7 @@
 .heading-xl,
 .heading-large,
 .heading-medium,
-.heading-small-mediium,
+.heading-small-medium,
 caption,
 h1,
 h2,
@@ -27,31 +27,26 @@ body {
 }
 
 h1,
-h1.heading-xxl,
 .heading-xxl {
   font-size: var(--typography-size-xxl);
 }
 
 h2,
-h2.heading-xl,
 .heading-xl {
   font-size: var(--typography-size-xl);
 }
 
 h3,
-h3.heading-large,
 .heading-large {
   font-size: var(--typography-size-large);
 }
 
 h4,
-h4.heading-medium,
 .heading-medium {
   font-size: var(--typography-size-medium);
 }
 
 h5,
-h5.heading-small-medium,
 .heading-small-medium {
   font-size: var(--typography-size-small-medium);
 }


### PR DESCRIPTION
Fixes a typo in typography class names and bumps the version for a new release.